### PR TITLE
Add tag support for posts and the skills marquee

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The theme ships with placeholder values. Search the project for `example.com`, `
 - `src/components/Layout.astro`: site name, social links, footer
 - `src/pages/index.astro`: tagline and person schema
 - `src/pages/about.astro`: bio and education
-- `src/lib/tags.ts`: skills list for the marquee, which also seed the `/tags/` archive
+- `src/lib/tags.ts`: skills list for the marquee, which also seeds the `/tags/` archive
 - `src/pages/rss.xml.ts` and `src/pages/blog/[slug].astro`: feed and author metadata
 - `public/robots.txt` and `public/.well-known/security.txt`: domain and contact
 - `public/assets/og.png`: social preview image, 1200x630 (a plain placeholder is included)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Based on the website theme from [herdr](https://github.com/ogulcancelik/herdr) b
 
 - 18 color palettes (Catppuccin, Nord, Dracula, Gruvbox, Tokyo Night, Rosé Pine, Kanagawa, Solarized, and others), defined as plain CSS variables and switchable at runtime
 - Home, blog, and about pages, an RSS feed, and a sitemap
+- Tags: optional per-post tags, a browsable `/tags/` archive, and tag chips on posts
 - Client-side search via [Pagefind](https://pagefind.app), opened with Ctrl/Cmd+K, with shell-style history recall on the arrow keys
 - Table of contents on posts, generated from level-two headings
 - Optional [Remark42](https://remark42.com) comments
@@ -49,7 +50,7 @@ The theme ships with placeholder values. Search the project for `example.com`, `
 - `src/components/Layout.astro`: site name, social links, footer
 - `src/pages/index.astro`: tagline and person schema
 - `src/pages/about.astro`: bio and education
-- `src/components/SkillsMarquee.astro`: skills list
+- `src/lib/tags.ts`: skills list for the marquee, which also seed the `/tags/` archive
 - `src/pages/rss.xml.ts` and `src/pages/blog/[slug].astro`: feed and author metadata
 - `public/robots.txt` and `public/.well-known/security.txt`: domain and contact
 - `public/assets/og.png`: social preview image, 1200x630 (a plain placeholder is included)
@@ -58,7 +59,7 @@ Comments stay disabled unless you run a Remark42 instance. The configuration is 
 
 ## Writing posts
 
-Posts are markdown files in `src/content/blog/` with `title`, `description`, `date`, and optional `draft` frontmatter. `example-post.md` shows the frontmatter and the supported markdown.
+Posts are markdown files in `src/content/blog/` with `title`, `description`, `date`, optional `tags`, and optional `draft` frontmatter. Each tag links to its archive page under `/tags/`. `example-post.md` shows the frontmatter and the supported markdown.
 
 ## Project structure
 
@@ -66,7 +67,8 @@ Posts are markdown files in `src/content/blog/` with `title`, `description`, `da
 src/
   components/     Layout (nav, search, theme switcher), TypedLede, SkillsMarquee
   content/blog/   posts as markdown
-  pages/          index (home), blog/, about, 404, rss
+  lib/            tags: skills list and tag helpers
+  pages/          index (home), blog/, tags/, about, 404, rss
 public/
   css/style.css   all styling, including palette definitions
   assets/         font, og image

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -964,6 +964,63 @@ button.nav-icon-link {
     color: var(--accent);
 }
 
+/* ===== Tags ===== */
+
+.post-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0.7rem 0 0 !important;
+}
+
+.tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.14rem 0.6rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 999px;
+    color: var(--muted);
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.4;
+    text-decoration: none;
+    transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.tag:hover {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--line-strong));
+    background: var(--accent-soft);
+}
+
+.tag-count {
+    color: var(--muted-2);
+    font-weight: 400;
+}
+
+.tag-cloud {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.tag-cloud .tag {
+    font-size: 0.78rem;
+    padding: 0.22rem 0.75rem;
+}
+
+.inline-link {
+    color: var(--accent);
+    font-family: var(--mono);
+    font-weight: 600;
+}
+
+.inline-link:hover {
+    text-decoration: underline;
+}
+
 /* ===== Article layout ===== */
 
 .post-meta {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -970,7 +970,15 @@ button.nav-icon-link {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-    margin: 0.7rem 0 0 !important;
+}
+
+/* On post cards the chips are a sibling of the card link, not a child
+   (anchors can't nest), so pull them up into the link's bottom padding
+   and restore the card's spacing below. The .post-card scope also beats
+   the `.post-card p` margin rule without needing !important. */
+.post-card .post-tags {
+    margin: -0.85rem 0 0;
+    padding: 0 0 1.45rem;
 }
 
 .tag {

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,32 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { formatPostDate, postSlug } from '../lib/posts';
+import { slugifyTag } from '../lib/tags';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+  latest?: boolean;
+}
+
+const { post, latest = false } = Astro.props;
+// Tags whose slug is empty have no archive page; skip their chips.
+const tags = post.data.tags.filter((tag) => slugifyTag(tag) !== '');
+---
+
+<article class="post-card">
+  <a class="post-card-link" href={`/blog/${postSlug(post)}/`}>
+    <div>
+      <h2>{post.data.title}{latest && <span class="tag-latest">latest</span>}</h2>
+      <p>{post.data.description}</p>
+      <p class="post-card-meta">{formatPostDate(post.data.date)}</p>
+    </div>
+  </a>
+  {/* Chips are siblings of the card link, not children: anchors can't nest. */}
+  {tags.length > 0 && (
+    <p class="post-tags">
+      {tags.map((tag) => (
+        <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>#{tag}</a>
+      ))}
+    </p>
+  )}
+</article>

--- a/src/components/SkillsMarquee.astro
+++ b/src/components/SkillsMarquee.astro
@@ -1,21 +1,17 @@
 ---
-// Replace with your own skills, tools, or interests.
-const skills = [
-  'HTML', 'CSS', 'JavaScript', 'TypeScript',
-  'Python', 'Go', 'Rust', 'Bash',
-  'Git', 'GitHub Actions', 'Docker', 'Kubernetes',
-  'AWS', 'Azure', 'GCP',
-  'PostgreSQL', 'Redis', 'GraphQL', 'REST APIs',
-  'Linux', 'Terraform', 'Ansible', 'CI/CD',
-];
+import { skills, slugifyTag } from '../lib/tags';
 ---
 
 <section class="skills-marquee" aria-label="Skills">
   <ul class="visually-hidden">
-    {skills.map((skill) => <li>{skill}</li>)}
+    {skills.map((skill) => (
+      <li><a href={`/tags/${slugifyTag(skill)}/`}>{skill}</a></li>
+    ))}
   </ul>
   {/* Two copies make the loop seamless; hidden from readers and search. */}
   <div class="skills-track" aria-hidden="true" data-pagefind-ignore>
-    {[...skills, ...skills].map((skill) => <span class="skills-item">{skill}</span>)}
+    {[...skills, ...skills].map((skill) => (
+      <a class="skills-item" href={`/tags/${slugifyTag(skill)}/`}>{skill}</a>
+    ))}
   </div>
 </section>

--- a/src/components/SkillsMarquee.astro
+++ b/src/components/SkillsMarquee.astro
@@ -8,10 +8,12 @@ import { skills, slugifyTag } from '../lib/tags';
       <li><a href={`/tags/${slugifyTag(skill)}/`}>{skill}</a></li>
     ))}
   </ul>
-  {/* Two copies make the loop seamless; hidden from readers and search. */}
+  {/* Two copies make the loop seamless; hidden from readers and search.
+      tabindex="-1" keeps the aria-hidden copies out of the tab order —
+      the visually-hidden list above is the keyboard-reachable one. */}
   <div class="skills-track" aria-hidden="true" data-pagefind-ignore>
     {[...skills, ...skills].map((skill) => (
-      <a class="skills-item" href={`/tags/${slugifyTag(skill)}/`}>{skill}</a>
+      <a class="skills-item" href={`/tags/${slugifyTag(skill)}/`} tabindex="-1">{skill}</a>
     ))}
   </div>
 </section>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,6 +8,7 @@ const blog = defineCollection({
     title: z.string(),
     description: z.string(),
     date: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
   }),
 });

--- a/src/content/blog/example-post.md
+++ b/src/content/blog/example-post.md
@@ -2,10 +2,15 @@
 title: "An Example Post"
 description: "A sample post showing the frontmatter fields and the markdown features this site supports."
 date: 2026-01-01
+tags:
+  - Astro
+  - Markdown
 draft: false
 ---
 
 This is an example post. Every post is a markdown file in `src/content/blog/` with four frontmatter fields: `title`, `description`, `date`, and an optional `draft` flag. Set `draft: true` to keep a post out of the build while you work on it.
+
+Posts can also list any number of `tags`. Each tag becomes a chip on the post and links to its own archive page under `/tags/`, alongside the skills marquee at the bottom of the site.
 
 The opening paragraph before the first heading works well as an introduction. It shows up in search results and gives readers a reason to keep going.
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,17 @@
+import type { CollectionEntry } from 'astro:content';
+
+// Route slug for a post: its file id without the markdown extension.
+// Used everywhere a /blog/<slug>/ URL is built, so the rule lives once.
+export function postSlug(post: CollectionEntry<'blog'>): string {
+  return post.id.replace(/\.(md|mdx)$/i, '');
+}
+
+// The one date format posts display, e.g. "January 1, 2026".
+export function formatPostDate(date: Date): string {
+  return date.toLocaleDateString('en', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,15 @@
+export const skills = [
+  'HTML', 'CSS', 'JavaScript', 'TypeScript',
+  'Python', 'Go', 'Rust', 'Bash',
+  'Git', 'GitHub Actions', 'Docker', 'Kubernetes',
+  'AWS', 'Azure', 'GCP',
+  'PostgreSQL', 'Redis', 'GraphQL', 'REST APIs',
+  'Linux', 'Terraform', 'Ansible', 'CI/CD',
+];
+
+export function slugifyTag(tag: string): string {
+  return tag
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,3 +1,8 @@
+import type { CollectionEntry } from 'astro:content';
+
+// Replace with your own skills, tools, or interests. Each one seeds a page
+// in the /tags/ archive, so marquee items link somewhere even before any
+// post uses them as a tag.
 export const skills = [
   'HTML', 'CSS', 'JavaScript', 'TypeScript',
   'Python', 'Go', 'Rust', 'Bash',
@@ -7,9 +12,50 @@ export const skills = [
   'Linux', 'Terraform', 'Ansible', 'CI/CD',
 ];
 
+// URL slug for a tag. Letters and digits in any script are kept (lowercased),
+// every other run of characters collapses to a hyphen: "GitHub Actions" ->
+// "github-actions", "C++" -> "c", "日本語" -> "日本語". A tag with no letters
+// or digits at all (e.g. "***") slugifies to "" — getAllTags and the tag-chip
+// renderers skip those, since an empty route param would fail the build.
 export function slugifyTag(tag: string): string {
   return tag
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/[^\p{Letter}\p{Number}]+/gu, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+export interface TagInfo {
+  slug: string;
+  name: string;
+  count: number;
+}
+
+// The site's tag universe: the skills list plus every tag on a published
+// (non-draft) post, one entry per slug. Draft posts are excluded so an
+// unpublished tag never gets a public archive page. When different spellings
+// share a slug, the display name comes from the skills list first, otherwise
+// from the first published post that uses it. `count` is the number of
+// published posts carrying the tag.
+export function getAllTags(posts: CollectionEntry<'blog'>[]): TagInfo[] {
+  const bySlug = new Map<string, TagInfo>();
+
+  for (const skill of skills) {
+    const slug = slugifyTag(skill);
+    if (slug) bySlug.set(slug, { slug, name: skill, count: 0 });
+  }
+
+  for (const post of posts) {
+    if (post.data.draft) continue;
+    const seen = new Set<string>();
+    for (const tag of post.data.tags) {
+      const slug = slugifyTag(tag);
+      if (!slug || seen.has(slug)) continue;
+      seen.add(slug);
+      const existing = bySlug.get(slug);
+      if (existing) existing.count += 1;
+      else bySlug.set(slug, { slug, name: tag, count: 1 });
+    }
+  }
+
+  return [...bySlug.values()].sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import Layout from '../../components/Layout.astro';
+import { slugifyTag } from '../../lib/tags';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -65,6 +66,9 @@ const postSchema = JSON.stringify({
                 timeZone: 'UTC',
               })}
             </time>
+            {post.data.tags.map((tag) => (
+              <a href={`/tags/${slugifyTag(tag)}/`}>#{slugifyTag(tag)}</a>
+            ))}
           </p>
           <h1>{post.data.title}</h1>
           <p>{post.data.description}</p>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import Layout from '../../components/Layout.astro';
+import { formatPostDate, postSlug } from '../../lib/posts';
 import { slugifyTag } from '../../lib/tags';
 
 export async function getStaticPaths() {
@@ -8,7 +9,7 @@ export async function getStaticPaths() {
   return posts
     .filter((post) => !post.data.draft)
     .map((post) => {
-      const slug = post.id.replace(/\.(md|mdx)$/i, '');
+      const slug = postSlug(post);
       return {
         params: { slug },
         props: { post, slug },
@@ -19,6 +20,8 @@ export async function getStaticPaths() {
 const { post, slug } = Astro.props;
 const { Content, headings } = await render(post);
 const sectionHeadings = headings.filter((heading) => heading.depth === 2);
+// Tags whose slug is empty have no archive page; skip their chips.
+const tags = post.data.tags.filter((tag) => slugifyTag(tag) !== '');
 
 const postSchema = JSON.stringify({
   '@context': 'https://schema.org',
@@ -59,15 +62,11 @@ const postSchema = JSON.stringify({
         <header class="article-header">
           <p class="post-meta">
             <time datetime={post.data.date.toISOString()}>
-              {post.data.date.toLocaleDateString('en', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-                timeZone: 'UTC',
-              })}
+              {formatPostDate(post.data.date)}
             </time>
-            {post.data.tags.map((tag) => (
-              <a href={`/tags/${slugifyTag(tag)}/`}>#{slugifyTag(tag)}</a>
+            {/* data-pagefind-ignore keeps tag labels out of the search index. */}
+            {tags.map((tag) => (
+              <a href={`/tags/${slugifyTag(tag)}/`} data-pagefind-ignore>#{tag}</a>
             ))}
           </p>
           <h1>{post.data.title}</h1>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,11 +3,10 @@ import { getCollection } from 'astro:content';
 import Layout from '../../components/Layout.astro';
 import TypedLede from '../../components/TypedLede.astro';
 import SkillsMarquee from '../../components/SkillsMarquee.astro';
-import { slugifyTag } from '../../lib/tags';
+import PostCard from '../../components/PostCard.astro';
 
 const posts = (await getCollection('blog'))
   .filter((post) => !post.data.draft)
-  .map((post) => ({ ...post, slug: post.id.replace(/\.(md|mdx)$/i, '') }))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 
@@ -27,24 +26,7 @@ const posts = (await getCollection('blog'))
         <p style="color: var(--muted); font-family: var(--mono);">No posts yet, check back soon.</p>
       ) : (
         <div class="post-list">
-          {posts.map((post, index) => (
-            <article class="post-card">
-              <a class="post-card-link" href={`/blog/${post.slug}/`}>
-                <div>
-                  <h2>{post.data.title}{index === 0 && <span class="tag-latest">latest</span>}</h2>
-                  <p>{post.data.description}</p>
-                  <p class="post-card-meta">{post.data.date.toLocaleDateString('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</p>
-                  {post.data.tags.length > 0 && (
-                    <p class="post-tags">
-                      {post.data.tags.map((tag) => (
-                        <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>#{slugifyTag(tag)}</a>
-                      ))}
-                    </p>
-                  )}
-                </div>
-              </a>
-            </article>
-          ))}
+          {posts.map((post, index) => <PostCard post={post} latest={index === 0} />)}
         </div>
       )}
     </section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import Layout from '../../components/Layout.astro';
 import TypedLede from '../../components/TypedLede.astro';
 import SkillsMarquee from '../../components/SkillsMarquee.astro';
+import { slugifyTag } from '../../lib/tags';
 
 const posts = (await getCollection('blog'))
   .filter((post) => !post.data.draft)
@@ -33,6 +34,13 @@ const posts = (await getCollection('blog'))
                   <h2>{post.data.title}{index === 0 && <span class="tag-latest">latest</span>}</h2>
                   <p>{post.data.description}</p>
                   <p class="post-card-meta">{post.data.date.toLocaleDateString('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</p>
+                  {post.data.tags.length > 0 && (
+                    <p class="post-tags">
+                      {post.data.tags.map((tag) => (
+                        <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>#{slugifyTag(tag)}</a>
+                      ))}
+                    </p>
+                  )}
                 </div>
               </a>
             </article>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,10 +3,10 @@ import { getCollection } from 'astro:content';
 import Layout from '../components/Layout.astro';
 import TypedLede from '../components/TypedLede.astro';
 import SkillsMarquee from '../components/SkillsMarquee.astro';
+import { formatPostDate, postSlug } from '../lib/posts';
 
 const posts = (await getCollection('blog'))
   .filter((post) => !post.data.draft)
-  .map((post) => ({ ...post, slug: post.id.replace(/\.(md|mdx)$/i, '') }))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, 3);
 
@@ -43,9 +43,9 @@ const personSchema = JSON.stringify({
         <nav class="commit-tree" aria-label="Recent posts">
           <a class="commit-tree-head" href="/blog/" title="All posts">Blog</a>
           {posts.map((post) => (
-            <a href={`/blog/${post.slug}/`}>
+            <a href={`/blog/${postSlug(post)}/`}>
               {post.data.title}
-              <span class="commit-tree-date">{post.data.date.toLocaleDateString('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</span>
+              <span class="commit-tree-date">{formatPostDate(post.data.date)}</span>
             </a>
           ))}
           <a href="/about/">About</a>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
+import { postSlug } from '../lib/posts';
 
 export async function GET(context: APIContext) {
   const posts = (await getCollection('blog'))
@@ -16,7 +17,7 @@ export async function GET(context: APIContext) {
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.date,
-      link: `/blog/${post.id.replace(/\.(md|mdx)$/i, '')}/`,
+      link: `/blog/${postSlug(post)}/`,
     })),
     customData: '<language>en-us</language>',
   });

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,68 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../components/Layout.astro';
+import { skills, slugifyTag } from '../../lib/tags';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const names = new Map<string, string>();
+  for (const post of posts) {
+    for (const tag of post.data.tags ?? []) {
+      names.set(slugifyTag(tag), tag);
+    }
+  }
+  for (const skill of skills) names.set(slugifyTag(skill), skill);
+
+  return [...names].map(([slug, name]) => ({ params: { tag: slug }, props: { name } }));
+}
+
+const { name } = Astro.props;
+const slug = Astro.params.tag!;
+
+const taggedPosts = (await getCollection('blog'))
+  .filter((post) => !post.data.draft)
+  .filter((post) => (post.data.tags ?? []).some((tag) => slugifyTag(tag) === slug))
+  .map((post) => ({ ...post, slug: post.id.replace(/\.(md|mdx)$/i, '') }))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+
+<Layout
+  title={`#${slug} — Your Name`}
+  description={`Posts tagged "${name}".`}
+  canonicalPath={`/tags/${slug}/`}
+>
+  <main class="content-shell">
+    <section class="page-hero">
+      <p class="eyebrow"><span class="status-dot dot-blue"></span>tag</p>
+      <h1># {name}</h1>
+      <p class="hero-lede">
+        {taggedPosts.length === 0
+          ? 'Nothing here yet — check back soon.'
+          : `${taggedPosts.length} post${taggedPosts.length === 1 ? '' : 's'} tagged ${name}.`}{' '}
+        <a class="inline-link" href="/tags/">all tags</a>
+      </p>
+    </section>
+
+    {taggedPosts.length > 0 ? (
+      <section class="section" aria-label="Posts">
+        <div class="post-list">
+          {taggedPosts.map((post) => (
+            <article class="post-card">
+              <a class="post-card-link" href={`/blog/${post.slug}/`}>
+                <div>
+                  <h2>{post.data.title}</h2>
+                  <p>{post.data.description}</p>
+                  <p class="post-card-meta">{post.data.date.toLocaleDateString('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</p>
+                </div>
+              </a>
+            </article>
+          ))}
+        </div>
+      </section>
+    ) : (
+      <section class="section">
+        <p style="color: var(--muted); font-family: var(--mono);">Nothing tagged # {name} yet.</p>
+      </section>
+    )}
+  </main>
+</Layout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,33 +1,38 @@
 ---
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import Layout from '../../components/Layout.astro';
-import { skills, slugifyTag } from '../../lib/tags';
+import PostCard from '../../components/PostCard.astro';
+import { getAllTags, slugifyTag } from '../../lib/tags';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
-  const names = new Map<string, string>();
-  for (const post of posts) {
-    for (const tag of post.data.tags ?? []) {
-      names.set(slugifyTag(tag), tag);
-    }
-  }
-  for (const skill of skills) names.set(slugifyTag(skill), skill);
+  const published = posts
+    .filter((post) => !post.data.draft)
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
-  return [...names].map(([slug, name]) => ({ params: { tag: slug }, props: { name } }));
+  return getAllTags(posts).map(({ slug, name }) => ({
+    params: { tag: slug },
+    props: {
+      name,
+      posts: published.filter((post) =>
+        post.data.tags.some((tag) => slugifyTag(tag) === slug),
+      ),
+    },
+  }));
 }
 
-const { name } = Astro.props;
-const slug = Astro.params.tag!;
+interface Props {
+  name: string;
+  posts: CollectionEntry<'blog'>[];
+}
 
-const taggedPosts = (await getCollection('blog'))
-  .filter((post) => !post.data.draft)
-  .filter((post) => (post.data.tags ?? []).some((tag) => slugifyTag(tag) === slug))
-  .map((post) => ({ ...post, slug: post.id.replace(/\.(md|mdx)$/i, '') }))
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+const { name, posts } = Astro.props;
+const slug = Astro.params.tag!;
 ---
 
 <Layout
-  title={`#${slug} — Your Name`}
+  title={`#${name} — Your Name`}
   description={`Posts tagged "${name}".`}
   canonicalPath={`/tags/${slug}/`}
 >
@@ -36,32 +41,18 @@ const taggedPosts = (await getCollection('blog'))
       <p class="eyebrow"><span class="status-dot dot-blue"></span>tag</p>
       <h1># {name}</h1>
       <p class="hero-lede">
-        {taggedPosts.length === 0
+        {posts.length === 0
           ? 'Nothing here yet — check back soon.'
-          : `${taggedPosts.length} post${taggedPosts.length === 1 ? '' : 's'} tagged ${name}.`}{' '}
+          : `${posts.length} post${posts.length === 1 ? '' : 's'} tagged ${name}.`}{' '}
         <a class="inline-link" href="/tags/">all tags</a>
       </p>
     </section>
 
-    {taggedPosts.length > 0 ? (
+    {posts.length > 0 && (
       <section class="section" aria-label="Posts">
         <div class="post-list">
-          {taggedPosts.map((post) => (
-            <article class="post-card">
-              <a class="post-card-link" href={`/blog/${post.slug}/`}>
-                <div>
-                  <h2>{post.data.title}</h2>
-                  <p>{post.data.description}</p>
-                  <p class="post-card-meta">{post.data.date.toLocaleDateString('en', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' })}</p>
-                </div>
-              </a>
-            </article>
-          ))}
+          {posts.map((post) => <PostCard post={post} />)}
         </div>
-      </section>
-    ) : (
-      <section class="section">
-        <p style="color: var(--muted); font-family: var(--mono);">Nothing tagged # {name} yet.</p>
       </section>
     )}
   </main>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -2,21 +2,9 @@
 import { getCollection } from 'astro:content';
 import Layout from '../../components/Layout.astro';
 import TypedLede from '../../components/TypedLede.astro';
-import { skills, slugifyTag } from '../../lib/tags';
+import { getAllTags } from '../../lib/tags';
 
-const posts = (await getCollection('blog')).filter((post) => !post.data.draft);
-
-const counts = new Map<string, number>();
-for (const post of posts) {
-  for (const tag of post.data.tags ?? []) {
-    const slug = slugifyTag(tag);
-    counts.set(slug, (counts.get(slug) ?? 0) + 1);
-  }
-}
-
-const tags = [...new Set(skills.map(slugifyTag))];
-for (const slug of counts.keys()) if (!tags.includes(slug)) tags.push(slug);
-tags.sort();
+const tags = getAllTags(await getCollection('blog'));
 ---
 
 <Layout
@@ -32,8 +20,8 @@ tags.sort();
 
     <section class="section" aria-label="Tags">
       <div class="tag-cloud">
-        {tags.map((slug) => (
-          <a class="tag" href={`/tags/${slug}/`}>#{slug} {counts.has(slug) && <span class="tag-count">{counts.get(slug)}</span>}</a>
+        {tags.map(({ slug, name, count }) => (
+          <a class="tag" href={`/tags/${slug}/`}>#{name} {count > 0 && <span class="tag-count">{count}</span>}</a>
         ))}
       </div>
     </section>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../components/Layout.astro';
+import TypedLede from '../../components/TypedLede.astro';
+import { skills, slugifyTag } from '../../lib/tags';
+
+const posts = (await getCollection('blog')).filter((post) => !post.data.draft);
+
+const counts = new Map<string, number>();
+for (const post of posts) {
+  for (const tag of post.data.tags ?? []) {
+    const slug = slugifyTag(tag);
+    counts.set(slug, (counts.get(slug) ?? 0) + 1);
+  }
+}
+
+const tags = [...new Set(skills.map(slugifyTag))];
+for (const slug of counts.keys()) if (!tags.includes(slug)) tags.push(slug);
+tags.sort();
+---
+
+<Layout
+  title="Tags — Your Name"
+  description="Posts grouped by tag."
+  canonicalPath="/tags/"
+>
+  <main class="content-shell">
+    <section class="page-hero">
+      <h1 class="visually-hidden">Tags</h1>
+      <TypedLede text="Posts grouped by tag." />
+    </section>
+
+    <section class="section" aria-label="Tags">
+      <div class="tag-cloud">
+        {tags.map((slug) => (
+          <a class="tag" href={`/tags/${slug}/`}>#{slug} {counts.has(slug) && <span class="tag-count">{counts.get(slug)}</span>}</a>
+        ))}
+      </div>
+    </section>
+  </main>
+</Layout>


### PR DESCRIPTION
Adds an optional per-post tagging system:

- **	ags frontmatter**: posts can list any number of tags (optional; defaults to empty)
- **Tag chips**: tags render as chips on the blog index cards and in the post header meta
- **/tags/ archive**: an index of all tags with post counts, plus a page per tag listing its posts
- **Clickable skills marquee**: each item in the skills marquee now links to its tag archive page; the marquee's skills list (in src/lib/tags.ts) seeds the archive so every marquee item resolves to a page, even before any post uses it

New files:
- src/lib/tags.ts - skills list (moved from SkillsMarquee.astro) plus slugifyTag
- src/pages/tags/index.astro and src/pages/tags/[tag].astro

Docs: README features/writing-posts/project-structure updated, and example-post.md now demonstrates the 	ags frontmatter.

Verified with 
pm run check (0 errors) and 
pm run build (all pages generated).